### PR TITLE
26690 gtm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "dennisdigital/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "drupal/google_tag": "dennis-8.x-1.x-dev#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         },
         {
             "type": "vcs",
+            "vendor-alias": "dennisdigital",
             "url": "git@github.com:dennisinteractive/google_tag.git"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/dennisinteractive/google_tag"
+            "url": "git@github.com:dennisinteractive/google_tag.git",
+            "no-api": true
         }
     ],
 
@@ -32,6 +33,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "drupal/google_tag": "dev-dennis-8.x-1.x"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x"
+        "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "drupal/google_tag": "dennis-8.x-1.x-dev#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         },
         {
             "type": "vcs",
-            "url": "git@github.com:dennisinteractive/google_tag.git"
+            "url": "https://github.com/dennisinteractive/google_tag"
         }
     ],
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         },
         {
             "type": "vcs",
-            "vendor-alias": "dennisdigital",
             "url": "git@github.com:dennisinteractive/google_tag.git"
         }
     ],
@@ -33,6 +32,6 @@
         "drupal/config_token": "1.x-dev#ee626183c4b75b901a9edb63c1e614516e9c3ba6",
         "drupal/domain": "1.0.0-alpha6",
         "drupal/paragraphs": "^1.0",
-        "dennisdigital/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
+        "drupal/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9"
     }
 }


### PR DESCRIPTION
Due to a vendor name problem in the original name we still need to keep 
` "solotandem/google_tag": "dev-dennis-8.x-1.x#66c4b40247dfcbc895cc544f62ca9a8be9fcc6f9",
`

once this has been solved in the origin we'll be able to change it to drupal/google_tag.

I've tried few workarounds but it didn't do the trick.

An issue has been open and acepted here https://www.drupal.org/node/2845873
It only needs for the maintainer to merge to the branch.